### PR TITLE
Upload artfacts after making dev build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,3 +80,9 @@ jobs:
           apple_id_password: ${{ secrets.APPLEID_PASSWORD }}
           cert_p12: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
           cert_passphrase: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSPHRASE }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: zui-insiders-installers
+          path: dist/installers


### PR DESCRIPTION
In #3, I hadn't noticed that this was missing the step to save the artifacts.