### PR TITLE
Use replacement for deprecated set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get Version
         id: get
-        run: echo "::set-output name=version::$(yarn latest)"
+        run: echo "version=$(yarn latest)" >> $GITHUB_OUTPUT
 
   release:
     name: Build and Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get Version
         id: get
-        run: echo "::set-output name=version::$(yarn latest)"
+        run: echo "version=$(yarn latest)" >> $GITHUB_OUTPUT
 
   release:
     name: Build and Publish


### PR DESCRIPTION
It was recently [announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) that the `set-output` syntax is being deprecated in Actions. I tested out the replacement syntax in a personal repo to get a feel for it and it works as described, so here's changes to our own Workflows to adopt the new approach.