### PR TITLE
Start using actions/setup-node@v3 due to deprecation warnings

### DIFF
--- a/.github/actions/setup-insiders/action.yml
+++ b/.github/actions/setup-insiders/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         cache: yarn
         cache-dependency-path: ${{ inputs.path }}/yarn.lock


### PR DESCRIPTION
See https://github.com/brimdata/brim/pull/2588 for context.