### PR TITLE
Pin to same runner versions currently pointed at by "latest"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   latest:
     name: Get Latest Release Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.get.outputs.version }}
     steps:
@@ -33,7 +33,7 @@ jobs:
     needs: latest
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-2019, macos-12, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   latest:
     name: Get Latest Release Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.get.outputs.version }}
     steps:
@@ -27,7 +27,7 @@ jobs:
     needs: latest
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-2019, macos-12, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
This is a companion PR to #2633. I've given Windows and Ubuntu the same treatment so the two repos can move in lock-step and hence minimize surprises.