### PR TITLE
Pause creation of daily Zui Insiders releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create New Release
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '5 15 * * 1-5' # Every weekday at 5:15am
+# schedule:
+#   - cron: '5 15 * * 1-5' # Every weekday at 5:15am
 
 jobs:
   latest:


### PR DESCRIPTION
There recently was a breaking change to the Zed lake storage format, and this leaked out in a recent Zui Insiders release. As a result, Zui Insiders users that have updated to releases newer than [v0.30.1-196](https://github.com/brimdata/zui-insiders/releases/tag/v0.30.1-196) have seen the app come up in this state:

![image](https://user-images.githubusercontent.com/5934157/221638072-95caaac9-7266-40b8-ae00-a75d72ce5843.png)

Ideally we'd like to be able to hand these users the [Zed lake migration tools](https://github.com/brimdata/zed-lake-migration) that are being drafted and get them up & running in a newer format ASAP. However, it's my understanding that yet another breaking lake format change is still on the way, and I don't want to have some unknown count of users landing on a half-baked storage format that's neither "v1" nor "v2" and need even more customized guidance to get their data back (or require them to lose their data, which is admittedly fair game given the "beta" nature of Zui Inisders, but I'd still prefer to avoid it.)

To get out of the current situation, I just did a quick smoke test that confirmed that after getting into that broken state in a newer release like [v0.30.1-200](https://github.com/brimdata/zui-insiders/releases/tag/v0.30.1-200) I could reinstall [v0.30.1-196](https://github.com/brimdata/zui-insiders/releases/tag/v0.30.1-196) and my app & pools came up ok again. Therefore via this PR what I'd like to do is turn off the creation of daily Zui Insiders releases until we've settled the storage format. Once this PR merges I'll delete the releases newer than [v0.30.1-196](https://github.com/brimdata/zui-insiders/releases/tag/v0.30.1-196) and advise the Zui Insiders users on public Slack to downgrade for now.