### PR TITLE
Resume creation of daily releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create New Release
 
 on:
   workflow_dispatch:
-# schedule:
-#   - cron: '5 15 * * 1-5' # Every weekday at 5:15am
+  schedule:
+    - cron: '5 15 * * 1-5' # Every weekday at 5:15am
 
 jobs:
   latest:


### PR DESCRIPTION
The app repo is now pointing at a Zed commit that has the last of the breaking Zed lake storage changes, so that means we can start making Zui Insiders builds again and ask the users on public Slack to try using the migration kit. I've already kicked off a one-off release manually.