### PR TITLE
Add build variable for apple_team_id

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
           # Mac
           apple_id: ${{ secrets.APPLEID_USER }}
           apple_id_password: ${{ secrets.APPLEID_PASSWORD }}
+          apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
           cert_p12: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
           cert_passphrase: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSPHRASE }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           # Mac
           apple_id: ${{ secrets.APPLEID_USER }}
           apple_id_password: ${{ secrets.APPLEID_PASSWORD }}
+          apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
           cert_p12: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
           cert_passphrase: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSPHRASE }}
 


### PR DESCRIPTION
I've recently learned how `notarytool` requires this "team ID" setting. We had the secret defined in this repo for this variable, but we weren't referring to it in Actions.

I also see now why it took me so long to spot the problem. Looking at this code:

https://github.com/karaggeorge/electron-builder-notarize/blob/efb683af5f4c5428ea6aa02df6a09a360563bfa0/validate.js#L40-L50

My attention was drawn to the `notarytool not found, trying legacy.` message, so when I wasn't seeing it that message in my Actions runs, I assumed that the code path that tried to use `notarytool` was being skipped entirely (such as if the older `electron-builder-notarize` that pre-dated `notarytool` was still being used.) But now that I'm at the end of my journey I've confirmed with a `console.log` message in a personal fork of `electron-builder-notarize` that Zui Insiders build has been throwing that exception the whole time, hence landing in that blank `catch {}` and continuing on to the legacy notarization, which silently succeeds. 🙄 

Fixes https://github.com/brimdata/zui/issues/2779